### PR TITLE
Fix websockets functionality for Ignition 8.1.25+

### DIFF
--- a/IgnitionNodeRED-build/pom.xml
+++ b/IgnitionNodeRED-build/pom.xml
@@ -47,7 +47,7 @@
                     <moduleId>org.imdc.nodered.IgnitionNodeRED</moduleId>
                     <moduleName>${module-name}</moduleName>
                     <moduleDescription>${module-description}</moduleDescription>
-                    <moduleVersion>1.5.12.${timestamp}</moduleVersion>
+                    <moduleVersion>1.5.13.${timestamp}</moduleVersion>
                     <requiredIgnitionVersion>${ignition-platform-version}</requiredIgnitionVersion>
                     <requiredFrameworkVersion>8</requiredFrameworkVersion>
                     <licenseFile>license.html</licenseFile>

--- a/IgnitionNodeRED-gateway/src/main/java/org/imdc/nodered/servlet/NodeREDWebSocketServlet.java
+++ b/IgnitionNodeRED-gateway/src/main/java/org/imdc/nodered/servlet/NodeREDWebSocketServlet.java
@@ -34,7 +34,6 @@ public class NodeREDWebSocketServlet extends JettyWebSocketServlet {
     @Override
     public void configure(JettyWebSocketServletFactory factory) {
         factory.setMaxTextMessageSize(2 * MB);
-        factory.register(NodeREDWebSocketChannel.class);
         factory.setCreator(new NodeREDWebSocketCreator(getContext()));
     }
 

--- a/node-red-contrib-ignition/CHANGELOG.md
+++ b/node-red-contrib-ignition/CHANGELOG.md
@@ -37,3 +37,9 @@ August 15, 2021
 August 20, 2021
 
  * Added dependencies for ws, https-proxy-agent, and url
+
+### 1.5.13
+
+February 27, 2023
+
+ * Version bump only for alignment with Ignition module and support for 8.1.25+

--- a/node-red-contrib-ignition/package.json
+++ b/node-red-contrib-ignition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ignition-nodes",
-  "version": "1.5.11",
+  "version": "1.5.13",
   "description": "Adds support for reading, writing, and browsing tags in Ignition",
   "dependencies": {
 	  "ws": "^7.5.3",


### PR DESCRIPTION
### ⚙️ Summary

This PR applies one more fix to those from #32 related to how the websocket channel is setup.  With Jetty 9, we called both a _register_ and a _setCreator_ method in order to configure the websocket creation.  With Jetty 10, invoking that _register_ method seems to take precedence over our prescribed creator and drive use of a no-arg constructor for the class instead.  Removing that _register_ call is all that is needed.

### ☑️ QA Notes

Prior to this change, I was getting errors in Ignition logs when attempting to use the _ignition tag read ws_ node in Node-RED to connect to the gateway.  With this change, I was able to start receiving values on-change within Node-RED without any issues.

Fixes #34

